### PR TITLE
README: Added warning for versions newer than 5.7.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ If you don't know what version, start with the mbp and if it doesn't work ([Blan
 
 ## Installation
 
+**!! Warning: Versions newer than [5.7.19](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) have various issues with init order and kernel modules. For now it's not recommended to use anything newer**
+
 1. Reduce the size of the mac partition in MacOS
 2. Download ISO file from releases. (Use the command line to unzip (`unzip /path/to/file.zip`) or "The Unarchiver" app)
 3. Copy it to a USB using dd (or gdd if installed over brew): 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you don't know what version, start with the mbp and if it doesn't work ([Blan
 
 ## Installation
 
-**!! Warning: Versions newer than [5.7.19](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) have various issues with init order and kernel modules and it's not recommended to use those**
+*!! Warning: Versions newer than [5.7.19](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) are considered in-development builds and **should not** be used due to issues from within the kernel and the init system.*
 
 1. Reduce the size of the mac partition in MacOS
 2. Download ISO file from releases. (Use the command line to unzip (`unzip /path/to/file.zip`) or "The Unarchiver" app)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you don't know what version, start with the mbp and if it doesn't work ([Blan
 
 ## Installation
 
-**!! Warning: Versions newer than [5.7.19](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) have various issues with init order and kernel modules. For now it's not recommended to use anything newer**
+**!! Warning: Versions newer than [5.7.19](https://github.com/marcosfad/mbp-ubuntu/releases/tag/v20.04-5.7.19-1) have various issues with init order and kernel modules and it's not recommended to use those**
 
 1. Reduce the size of the mac partition in MacOS
 2. Download ISO file from releases. (Use the command line to unzip (`unzip /path/to/file.zip`) or "The Unarchiver" app)


### PR DESCRIPTION
As in practise a stable experience at the moment is only achiveable using kernel versions lower than 5.8.x there should be a warning in the readme. From my experience on the community discord, a newer version is the number 1 issue (new) people are having