### PR TITLE
README: Update link to wifi guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ sudo gdd bs=4M if=ubuntu-20.04-5.6.10-mbp.iso of=/dev/diskX conv=fdatasync statu
 
 ## Configuration
 
-- Put wifi firmware files to `/lib/firmware/brcm/`
-  - tutorial - <https://github.com/mikeeq/mbp-fedora-kernel/#working-with-mbp-fedora-kernel>
-  - this is not working with MBP 16,1
+- See <https://wiki.t2linux.org/guides/wifi/>
 - To install additional languages, install appropriate langpack via apt `sudo apt-get install language-pack-[cod] language-pack-gnome-[cod] language-pack-[cod]-base language-pack-gnome-[cod]-base `
     - see https://askubuntu.com/questions/149876/how-can-i-install-one-language-by-command-line
 - You can change mappings of ctrl, fn, option keys (PC keyboard mappings) by creating `/etc/modprobe.d/hid_apple.conf` file and recreating grub config. All available modifications could be found here: <https://github.com/free5lot/hid-apple-patched>

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ Check <https://github.com/marcosfad/mbp-ubuntu/blob/master/files/chroot_build.sh
 
 - Sound is not working after the install. Follow the instructions detailed by @kevineinarsson: <https://gist.github.com/kevineinarsson/8e5e92664f97508277fefef1b8015fba>  
 On MBP 16,1, you might also need to disable realtime scheduling if the above gist doesn't work, because the pulseaudio server might get killed if the realtime budget is exceeded (<https://bugs.freedesktop.org/show_bug.cgi?id=94629>). Just add `realtime-scheduling = no` to `/etc/pulse/daemon.conf`.
-- Wifi is not working for bali (MBP 16,1). I'm using a 10$ usb wifi.
 - Checksum is failing for 2 files: md5sum.txt and /boot/grub/bios.img
 - I'm having troubles shutting down ubuntu. Screen is black but fan keeps on working. I have to force shutdown. 
 


### PR DESCRIPTION
This replaces the outdated guide in mbp-fedora with a reference to the t2linux wiki.

Addtionally, the 16,1 model not supported notice has been removed, as there is support. As such, the repository description would also need to be updated