### PR TITLE
update to linux5.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,8 @@ jobs:
           name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.z03
           path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.z03
           
-      - name: Upload iso artifact part 4
+      - name: Upload iso artifact final part
+        if:  always()
         uses: actions/upload-artifact@v2
         with:
           name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.zip
@@ -62,7 +63,7 @@ jobs:
       - name: Instructions for putting it back together
         run: |
           echo Download all the artifacts, and put them in a folder without other files. Then run:
-          echo "for i in *; do file $i; done"
-          echo "cat livecd-${{ steps.tag.outputs.tag }}-mbp.z01 livecd-${{ steps.tag.outputs.tag }}-mbp.z02 livecd-${{ steps.tag.outputs.tag }}-mbp.z03 livecd-${{ steps.tag.outputs.tag }}-mbp.zip > cd.zip"
+          echo 'unzip "*.z??.zip"'
+          echo 'cat livecd-${{ steps.tag.outputs.tag }}-mbp.z?? > cd.zip'
           echo unzip cd.zip
           

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,5 +60,9 @@ jobs:
           path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.zip
 
       - name: Instructions for putting it back together
-        run: echo cat livecd-${{ steps.tag.outputs.tag }}-mbp.z01 livecd-${{ steps.tag.outputs.tag }}-mbp.z02 livecd-${{ steps.tag.outputs.tag }}-mbp.z03 livecd-${{ steps.tag.outputs.tag }}-mbp.zip
+        run: |
+          echo Download all the artifacts, and put them in a folder without other files. Then run:
+          echo "for i in *; do file $i; done"
+          echo "cat livecd-${{ steps.tag.outputs.tag }}-mbp.z01 livecd-${{ steps.tag.outputs.tag }}-mbp.z02 livecd-${{ steps.tag.outputs.tag }}-mbp.z03 livecd-${{ steps.tag.outputs.tag }}-mbp.zip > cd.zip"
+          echo unzip cd.zip
           

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,9 +35,30 @@ jobs:
           echo Version is $VER
           echo "::set-output name=tag::${VER}"
         
-      - name: Upload iso artifact
+      - name: Upload iso artifact part 1
         uses: actions/upload-artifact@v2
         with:
-          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}
-          path: ${{ github.workspace }}/*.iso
+          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.z01
+          path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.z01
+          
+      - name: Upload iso artifact part 2
+        uses: actions/upload-artifact@v2
+        with:
+          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.z02
+          path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.z02
+          
+      - name: Upload iso artifact part 3
+        uses: actions/upload-artifact@v2
+        with:
+          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.z03
+          path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.z03
+          
+      - name: Upload iso artifact part 4
+        uses: actions/upload-artifact@v2
+        with:
+          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}.zip
+          path: ${{ github.workspace }}/output/livecd-${{ steps.tag.outputs.tag }}-mbp.zip
+
+      - name: Instructions for putting it back together
+        run: echo cat livecd-${{ steps.tag.outputs.tag }}-mbp.z01 livecd-${{ steps.tag.outputs.tag }}-mbp.z02 livecd-${{ steps.tag.outputs.tag }}-mbp.z03 livecd-${{ steps.tag.outputs.tag }}-mbp.zip
           

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,43 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  [push]
+
+  # Allows you to run this workflow manually from the Actions tab
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Build
+        run: sudo ./build.sh
+
+      # Runs a set of commands using the runners shell
+      - name: print sha256sum
+        run: cat output/sha256
+        
+      - name: Generate Tag
+        id: tag
+        run: |
+          VER=$(egrep ^KERNEL_VERSION build.sh|cut -d= -f2)
+          echo Version is $VER
+          echo "::set-output name=tag::${VER}"
+        
+      - name: Upload iso artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: mbp-ubuntu-${{ steps.tag.outputs.tag }}
+          path: ${{ github.workspace }}/*.iso
+          

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ ROOT_PATH=$(pwd)
 WORKING_PATH=/root/work
 CHROOT_PATH="${WORKING_PATH}/chroot"
 IMAGE_PATH="${WORKING_PATH}/image"
-KERNEL_VERSION=5.9.6
+KERNEL_VERSION=5.10.47
 
 if [ -d "$WORKING_PATH" ]; then
   rm -rf "$WORKING_PATH"
@@ -33,7 +33,7 @@ apt-get install -y -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="
   syslinux
 
 echo >&2 "===]> Info: Start loop... "
-for ALTERNATIVE in mbp mbp-alt
+for ALTERNATIVE in mbp
 do
   echo >&2 "===]> Info: Start building ${ALTERNATIVE}... "
 

--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ do
   fi
   ### Zip iso and split it into multiple parts - github max size of release attachment is 2GB, where ISO is sometimes bigger than that
   cd "${ROOT_PATH}"
-  zip -s 1500m "${ROOT_PATH}/output/livecd-${KERNEL_VERSION}-${ALTERNATIVE}.zip" "${ROOT_PATH}/ubuntu-20.04-${KERNEL_VERSION}-${ALTERNATIVE}.iso"
+  zip -s 500m "${ROOT_PATH}/output/livecd-${KERNEL_VERSION}-${ALTERNATIVE}.zip" "${ROOT_PATH}/ubuntu-20.04-${KERNEL_VERSION}-${ALTERNATIVE}.iso"
 done
 ### Calculate sha256 sums of built ISO
 sha256sum "${ROOT_PATH}"/*.iso >"${ROOT_PATH}/output/sha256"

--- a/build.sh
+++ b/build.sh
@@ -79,7 +79,7 @@ do
   fi
   ### Zip iso and split it into multiple parts - github max size of release attachment is 2GB, where ISO is sometimes bigger than that
   cd "${ROOT_PATH}"
-  zip -s 500m "${ROOT_PATH}/output/livecd-${KERNEL_VERSION}-${ALTERNATIVE}.zip" "${ROOT_PATH}/ubuntu-20.04-${KERNEL_VERSION}-${ALTERNATIVE}.iso"
+  zip -s 1500m "${ROOT_PATH}/output/livecd-${KERNEL_VERSION}-${ALTERNATIVE}.zip" "${ROOT_PATH}/ubuntu-20.04-${KERNEL_VERSION}-${ALTERNATIVE}.iso"
 done
 ### Calculate sha256 sums of built ISO
 sha256sum "${ROOT_PATH}"/*.iso >"${ROOT_PATH}/output/sha256"


### PR DESCRIPTION
I've tested this on my MBP16,1 and it sets up everything except wifi.

- Added a CI that builds the iso, and uploads it in parts (if it's whole like [this](https://github.com/Redecorating/mbp-ubuntu/actions/runs/1017561260) it won't download)
- Merged the iwd branch, because it makes setting up wifi easier (and works)
- Gets the 5.10.47 kernel from [here](https://github.com/marcosfad/mbp-ubuntu-kernel/releases/tag/v5.10.47) as it wasn't on the apt repo. 
- No longer builds a mbp-alt version, as there's no longer a mbp-alt kernel.
- The `apple-bce` repo is changed to https://github.com/t2linux/apple-bce-drv.git
- The `apple-ibridge` repo is changed to https://github.com/t2linux/apple-ib-drv

If you want to test it you can use this iso or put together the parts from one of the ci runs.

https://github.com/Redecorating/mbp-ubuntu/releases/tag/v20.04-5.10.47-1