### PR TITLE
install ubuntu-desktop jammy

### DIFF
--- a/files/chroot_build.sh
+++ b/files/chroot_build.sh
@@ -75,7 +75,7 @@ echo >&2 "===]> Info: Install window manager... "
 
 apt-get install -y -qq -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" \
   plymouth-theme-ubuntu-logo \
-  ubuntu-desktop-minimal \
+  ubuntu-desktop \
   ubuntu-gnome-wallpapers \
   snapd
 


### PR DESCRIPTION
As we are splitting the iso any way. It would good to generated the complete Ubuntu desktop to avoid users need to do manually after the installation. This affects jammy and mainline