### PR TITLE
readme: add disclaimer about using other tools instead of dd

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,20 @@ Bootloader is configure correctly out of the box. No workaround needed.
 
 1. Reduce the size of the mac partition in MacOS.
 2. Download ISO file from releases.
-3. Copy it to a USB using dd (or gdd if installed over brew): 
-```bash
-diskutil list # found which number has the USB
-diskutil umountDisk /dev/diskX
-sudo gdd bs=4M if=ubuntu-20.04-5.6.10-mbp.iso of=/dev/diskX conv=fdatasync status=progress
-```
-#### Note
-Other imaging tools such as Etcher or Rufus may not work as intended, if you are having trouble, use dd (or gdd if installed over brew)
+3. Copy it to a USB using dd (or gdd if installed over brew):
+
+   ```bash
+   diskutil list # found which number has the USB
+   diskutil umountDisk /dev/diskX
+   sudo gdd bs=4M if=ubuntu-20.04-5.6.10-mbp.iso of=/dev/diskX conv=fdatasync status=progress
+   ```
+
+   **Note :**
+   Other imaging tools such as Etcher or Rufus may not work as intended, if you are having trouble, use dd (or gdd if installed over brew).
+
 4. Boot in Recovery mode and allow booting unknown OS.
 5. Restart and immediately press and hold the option key until the Logo comes up.
-6. Select "EFI Boot" (the third option was the one that worked for me)
+6. Select "EFI Boot" (the rightmost option was the one that worked for me)
 7. Launch Ubuntu Live
 8. Use Ubiquity to install (just click on it)
 9. Select the options that work for you and use for the partition the following setup:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Bootloader is configure correctly out of the box. No workaround needed.
 
 ## Installation
 
-1. Reduce the size of the mac partition in MacOS
+1. Reduce the size of the mac partition in MacOS.
 2. Download ISO file from releases.
 3. Copy it to a USB using dd (or gdd if installed over brew): 
 ```bash
@@ -28,8 +28,10 @@ diskutil list # found which number has the USB
 diskutil umountDisk /dev/diskX
 sudo gdd bs=4M if=ubuntu-20.04-5.6.10-mbp.iso of=/dev/diskX conv=fdatasync status=progress
 ```
-4. Boot in Recovery mode and allow booting unknown OS
-5. Restart and immediately press the option key until the Logo come up
+#### Note
+Other imaging tools such as Etcher or Rufus may not work as intended, if you are having trouble, use dd (or gdd if installed over brew)
+4. Boot in Recovery mode and allow booting unknown OS.
+5. Restart and immediately press and hold the option key until the Logo comes up.
 6. Select "EFI Boot" (the third option was the one that worked for me)
 7. Launch Ubuntu Live
 8. Use Ubiquity to install (just click on it)

--- a/files/preseed/mbp164.seed
+++ b/files/preseed/mbp164.seed
@@ -8,4 +8,4 @@
 # well keep them installed.
 #ubiquity ubiquity/keep-installed string icedtea6-plugin openoffice.org
 
-d-i debian-installer/add-kernel-opts string pcie_ports=native intel_iommu=on iommu=pt nomodeset
+d-i debian-installer/add-kernel-opts string pcie_ports=native intel_iommu=on iommu=pt


### PR DESCRIPTION
Hello, recently after trying my hand in installing i found that the ISO doesn't work when flashed with etcher (and most likely other tools) not sure why but adding a disclaimer could save a user from wasting their time trying to "cut corners" and using etcher like I did.

Other than that just a few periods here and there I hope you find this small change worthwhile and keep up the good work with T2 :)