### PR TITLE
Make iso.sh Compatible with Both bash and sh

### DIFF
--- a/.github/workflows/iso.sh
+++ b/.github/workflows/iso.sh
@@ -82,7 +82,9 @@ case "$verinput" in
 		;;
 esac
 
-flavourcap=`echo ${flavour:0:1} | tr  '[a-z]' '[A-Z]'`${flavour:1}
+firstChar=$(echo "$flavour" | cut -c1 | tr '[a-z]' '[A-Z]')
+restOfString=$(echo "$flavour" | cut -c2-)
+flavourcap="${firstChar}${restOfString}"
 
 if [ ! -f ${iso}.z01 ]; then
 	echo -e "\nDownloading Part 1 for ${flavourcap} ${ver}"


### PR DESCRIPTION
Modified iso.sh to ensure compatibility with both bash and sh. The original script used bash-specific syntax that caused errors in sh. Changes were made to utilize cut and tr commands for string manipulation, avoiding bash-specific features.

## Changes

Used cut to extract the first character of the flavour variable.
Converted the first character to uppercase using tr.
Concatenated the modified first character with the rest of the flavour string using cut.
## Testing

Set the flavour variable (e.g., flavour="Ubuntu").
Execute with bash: bash iso.sh and verify correct output.
Execute with sh: sh `iso.sh` and confirm the output matches the bash execution.

## Related Issue
Fixes #109

## Notes
The update removes bash-specific syntax for broader shell compatibility.