### PR TITLE
feat: Add systemd service to auto-fetch Apple firmware and ensure its execution on first boot.

### DIFF
--- a/.github/workflows/iso.sh
+++ b/.github/workflows/iso.sh
@@ -3,25 +3,27 @@
 os=$(uname -s)
 case "$os" in
 	(Darwin)
-		true
+		echo -e "GET http://github.com HTTP/1.0\n\n" | nc github.com 80 > /dev/null 2>&1
+		if [ $? -eq 0 ]; then
+			true
+		else
+			echo "Please connect to the internet"
+			exit 1
+		fi
 		;;
 	(Linux)
-		true
+		if wget -q --spider --timeout=5 --tries=1 http://github.com >/dev/null 2>&1; then
+			true
+		else
+			echo "Please connect to the internet"
+			exit 1
+		fi
 		;;
 	(*)
 		echo "This script is meant to be run only on Linux or macOS"
 		exit 1
 		;;
 esac
-
-echo -e "GET http://github.com HTTP/1.0\n\n" | nc github.com 80 > /dev/null 2>&1
-
-if [ $? -eq 0 ]; then
-    true
-else
-    echo "Please connect to the internet"
-    exit 1
-fi
 
 set -e
 

--- a/02_build_image.sh
+++ b/02_build_image.sh
@@ -18,6 +18,8 @@ touch "${IMAGE_PATH}"/ubuntu
 cp -r "${ROOT_PATH}"/files/preseed "${IMAGE_PATH}"/preseed
 cp "${ROOT_PATH}/files/grub/grub.cfg" "${IMAGE_PATH}"/isolinux/grub.cfg
 
+echo >&2 "===]> Info: Reset firmware flag for fresh boot... "
+rm -f "${CHROOT_PATH}/etc/get_apple_firmware_attempted" || true
 
 echo >&2 "===]> Info: Compress the chroot... "
 cd "${WORKING_PATH}"

--- a/files/chroot_build.sh
+++ b/files/chroot_build.sh
@@ -125,21 +125,7 @@ printf 'apple-bce' >>/etc/modules-load.d/t2.conf
 
 echo >&2 "===]> Info: Setup auto-fetch firmware service... "
 
-cat <<'EOF' >/etc/systemd/system/get-apple-firmware.service
-[Unit]
-Description=Get Apple WiFi and Bluetooth firmware
-ConditionPathExists=!/etc/get_apple_firmware_attempted
-ConditionPathExists=/lib/firmware/brcm
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-ExecStart=-/usr/libexec/get-apple-firmware -i get_from_macos
-ExecStart=touch /etc/get_apple_firmware_attempted
-
-[Install]
-WantedBy=multi-user.target
-EOF
+curl -s https://raw.githubusercontent.com/t2linux/wiki/refs/heads/master/docs/tools/get-apple-firmware.service -o /etc/systemd/system/get-apple-firmware.service
 
 systemctl enable get-apple-firmware.service
 

--- a/files/chroot_build.sh
+++ b/files/chroot_build.sh
@@ -123,6 +123,26 @@ printf 'apple-bce' >>/etc/modules-load.d/t2.conf
 #printf '\n# display f* key in touchbar\noptions apple-ib-tb fnmode=1\n'  >> /etc/modprobe.d/apple-tb.conf
 #printf '\n# delay loading of the touchbar driver\ninstall apple-ib-tb /bin/sleep 7; /sbin/modprobe --ignore-install apple-ib-tb' >> /etc/modprobe.d/delay-tb.conf
 
+echo >&2 "===]> Info: Setup auto-fetch firmware service... "
+
+cat <<'EOF' >/etc/systemd/system/get-apple-firmware.service
+[Unit]
+Description=Get Apple WiFi and Bluetooth firmware
+ConditionPathExists=!/etc/get_apple_firmware_attempted
+ConditionPathExists=/lib/firmware/brcm
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/libexec/get-apple-firmware -i get_from_macos
+ExecStart=touch /etc/get_apple_firmware_attempted
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable get-apple-firmware.service
+
 echo >&2 "===]> Info: Update initramfs... "
 
 ## Add custom drivers to be loaded at boot


### PR DESCRIPTION
We could run the `get-apple-firmware` automatically to pull the firmware instead of having the users run it manually.

One less step in the install process?

I haven't been able to test this yet but pushing up here to get early feedback.

Based on a brief discussion in the Discord