### PR TITLE
Use curl for iso.sh connectivity check

### DIFF
--- a/.github/workflows/iso.sh
+++ b/.github/workflows/iso.sh
@@ -2,28 +2,23 @@
 
 os=$(uname -s)
 case "$os" in
-	(Darwin)
-		echo -e "GET http://github.com HTTP/1.0\n\n" | nc github.com 80 > /dev/null 2>&1
-		if [ $? -eq 0 ]; then
-			true
-		else
-			echo "Please connect to the internet"
-			exit 1
-		fi
-		;;
-	(Linux)
-		if wget -q --spider --timeout=5 --tries=1 http://github.com >/dev/null 2>&1; then
-			true
-		else
-			echo "Please connect to the internet"
-			exit 1
-		fi
+	(Darwin|Linux)
 		;;
 	(*)
 		echo "This script is meant to be run only on Linux or macOS"
 		exit 1
 		;;
 esac
+
+if ! command -v curl >/dev/null 2>&1; then
+	echo "Please install curl to proceed"
+	exit 1
+fi
+
+if ! curl -sfI --max-time 5 https://github.com >/dev/null 2>&1; then
+	echo "Please connect to the internet"
+	exit 1
+fi
 
 set -e
 


### PR DESCRIPTION
The connectivity probe used ```wget``` on Linux and ```nc``` on macOS, which caused the script to print "Please connect to the internet" when ```wget``` simply was not installed. 

Dropping ```nc``` as a separate branch in the script was just an opportunity, since curl ships with macOS. I understand if the maintainers don't want that in this PR.

Every actual download in the script already uses curl, so I dropped wget/nc paths, gate on curl being present (with an informative message), and use ```curl -sfI``` for the probe. Curl seems to be much more reliably installed than wget.

Would close #202 